### PR TITLE
Hide date field until a week is selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
     }
 
     input[type="date"],
+    select,
     textarea {
       width: 100%;
       padding: 0.75rem;
@@ -185,6 +186,8 @@
       margin-top: 0.25rem;
     }
 
+    .d-none { display: none; }
+
     /* Popup & confetti */
     #popup {
       display: none;
@@ -237,7 +240,8 @@
         width: 100%;
         min-width: auto;
       }
-      input[type="date"], textarea {
+      input[type="date"], select,
+      textarea {
         font-size: 0.95rem;
       }
     }
@@ -252,8 +256,12 @@
     <form id="surveyForm">
       <!-- Page 1 -->
       <section class="page active">
-        <label for="lunchDate">What day are you reviewing?</label>
-        <input type="date" id="lunchDate" name="lunchDate" required>
+        <label for="weekSelect">Which week are you reviewing?</label>
+        <select id="weekSelect" onchange="setWeekLabel()"></select>
+        <div id="dateGroup" class="d-none">
+          <label for="lunchDate">What day are you reviewing?</label>
+          <input type="date" id="lunchDate" name="lunchDate" required>
+        </div>
         <div class="buttons">
           <button type="button" onclick="nextPage()">Continue</button>
         </div>
@@ -323,14 +331,19 @@
     let currentPage = 0;
     const pages     = document.querySelectorAll('.page'),
           form      = document.getElementById('surveyForm'),
-          dateInput = document.getElementById('lunchDate');
+          dateInput = document.getElementById('lunchDate'),
+          weekSelect = document.getElementById('weekSelect');
 
     function showPage(i) {
       pages.forEach((p, idx) => p.classList.toggle('active', idx === i));
       currentPage = i;
       if (i === 0) {
-        dateInput.focus();
-        if (typeof dateInput.showPicker === 'function') dateInput.showPicker();
+        if (!weekSelect.value) {
+          weekSelect.focus();
+        } else {
+          dateInput.focus();
+          if (typeof dateInput.showPicker === 'function') dateInput.showPicker();
+        }
       }
     }
 
@@ -352,17 +365,52 @@
     };
     window.reviewAnother = () => closePopup();
 
-    function setWeekLabel() {
+    function getCurrentTuesday() {
       const now = new Date(),
-            day = now.getDay(),
-            diff = day < 2 ? day + 5 : day - 2,
-            tues = new Date(now.setDate(now.getDate() - diff)),
-            thurs = new Date(tues).setDate(tues.getDate() + 2),
-            opts = { month:'numeric', day:'numeric' },
-            lbl = document.getElementById('surveyWeek');
-      lbl.innerText = `Campus Lunch Survey ${new Date(tues).toLocaleDateString(undefined,opts)}–${new Date(thurs).toLocaleDateString(undefined,opts)}`;
-      dateInput.min = new Date(tues).toISOString().slice(0,10);
-      dateInput.max = new Date(thurs).toISOString().slice(0,10);
+            day = now.getDay();
+      return new Date(now.setDate(now.getDate() - (day < 2 ? day + 5 : day - 2)));
+    }
+
+    function generateWeekOptions(count = 8) {
+      const start = getCurrentTuesday();
+      const opts = { month:'numeric', day:'numeric' };
+      weekSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'Select a week';
+      placeholder.selected = true;
+      placeholder.defaultSelected = true;
+      placeholder.disabled = true;
+      weekSelect.append(placeholder);
+      for (let i=0;i<count;i++) {
+        const tues = new Date(start); tues.setDate(start.getDate() - i*7);
+        const end = new Date(tues); end.setDate(tues.getDate() + 2);
+        const opt = document.createElement('option');
+        opt.value = tues.toISOString().slice(0,10);
+        opt.textContent = `${tues.toLocaleDateString(undefined,opts)}–${end.toLocaleDateString(undefined,opts)}`;
+        weekSelect.append(opt);
+      }
+    }
+
+    function setWeekLabel() {
+      const opts = { month:'numeric', day:'numeric' },
+            lbl  = document.getElementById('surveyWeek'),
+            grp  = document.getElementById('dateGroup');
+      if (!weekSelect.value) {
+        lbl.innerText = 'Campus Lunch Survey';
+        dateInput.value = '';
+        dateInput.min = '';
+        dateInput.max = '';
+        grp.classList.add('d-none');
+        return;
+      }
+      let tues = new Date(weekSelect.value);
+      const end = new Date(tues); end.setDate(tues.getDate() + 2);
+      lbl.innerText = `Campus Lunch Survey ${tues.toLocaleDateString(undefined,opts)}–${end.toLocaleDateString(undefined,opts)}`;
+      dateInput.min = tues.toISOString().slice(0,10);
+      dateInput.max = end.toISOString().slice(0,10);
+      if (dateInput.value < dateInput.min || dateInput.value > dateInput.max) dateInput.value = '';
+      grp.classList.remove('d-none');
     }
 
     function createRatingBar(id, icons, hid) {
@@ -403,6 +451,7 @@
     });
 
     // init
+    generateWeekOptions();
     setWeekLabel();
     createRatingBar('tasteRating',       ['hotdog.png','hotdog.png','hotdog.png','hotdog.png','hotdog.png'],       'tasteRatingInput');
     createRatingBar('temperatureRating', ['fire.png','fire.png','fire.png','fire.png','fire.png'],             'temperatureRatingInput');

--- a/index.html
+++ b/index.html
@@ -8,21 +8,28 @@
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
     rel="stylesheet"/>
   <style>
-    /*--------------------------
-      Box-model & theme vars
-    ---------------------------*/
-    *, *::before, *::after { box-sizing: border-box; }
+    /*----------------------------
+      Reset & Theme Variables
+    -----------------------------*/
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
     :root {
       --primary: #8b0000;
       --primary-hover: #5a0000;
       --overlay: rgba(0,0,0,0.6);
       --bg-light: rgba(255,255,255,0.9);
-      --text: #333;
-      --label-color: #555;
+      --text: #000;
+      --label-color: #000;        /* make labels black */
+      --button-lift: -4px;
+      --button-shadow: 0 6px 12px rgba(0,0,0,0.15);
+      --shine-color: rgba(255,255,255,0.4);
+      --shine-duration: 0.7s;
     }
 
-    body {
-      margin: 0;
+    html, body {
       font-family: 'Inter', sans-serif;
       color: var(--text);
       background:
@@ -35,10 +42,13 @@
       min-height: 100vh;
       padding: 1rem;
     }
+    main { width: 100%; max-width: 700px; }
 
-    main {
-      width: 100%;
-      max-width: 700px;
+    /* remove all fieldset borders */
+    fieldset {
+      border: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
     }
 
     header.survey-title-box {
@@ -47,9 +57,9 @@
       border-radius: 8px;
       text-align: center;
       margin-bottom: 1rem;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     }
     .survey-title {
-      margin: 0;
       font-size: 1.75rem;
       font-weight: 600;
       color: var(--primary);
@@ -68,18 +78,10 @@
       text-align: center;
       font-weight: 600;
       font-size: 1rem;
+      color: var(--text);
     }
 
-    /* Remove the default box around each rating fieldset */
-    fieldset {
-      border: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    input[type="date"],
-    select,
-    textarea {
+    input[type="date"], textarea {
       width: 100%;
       padding: 0.75rem;
       margin-top: 0.5rem;
@@ -89,10 +91,7 @@
       font-size: 1rem;
       color: #222;
     }
-    textarea {
-      min-height: 120px;
-      resize: vertical;
-    }
+    textarea { min-height: 120px; resize: vertical; }
 
     .page { display: none; }
     .page.active { display: block; }
@@ -105,8 +104,10 @@
       margin-top: 2rem;
     }
 
-    /* Action buttons (with sheen) */
-    button:not(.emoji-container) {
+    /* —— Action Buttons —— */
+    button {
+      position: relative;
+      overflow: hidden;
       background: var(--primary);
       color: #fff;
       border: none;
@@ -116,21 +117,18 @@
       cursor: pointer;
       min-width: 120px;
       border-radius: 4px;
-      transition: background 0.3s, transform 0.2s, box-shadow 0.2s;
-      position: relative;
-      overflow: hidden;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
     }
-    button:not(.emoji-container):hover {
+    button:hover {
+      transform: translateY(var(--button-lift));
+      box-shadow: var(--button-shadow);
       background: var(--primary-hover);
-      transform: translateY(-4px);
-      box-shadow: 0 6px 12px rgba(0,0,0,0.15);
     }
-    button:not(.emoji-container):disabled {
+    button:disabled {
       opacity: 0.6;
       cursor: default;
     }
-    /* Sheen */
-    button:not(.emoji-container)::before {
+    button::before {
       content: '';
       position: absolute;
       top: -100%;
@@ -140,55 +138,58 @@
       background: linear-gradient(
         45deg,
         transparent 0%,
-        rgba(255,255,255,0.4) 50%,
+        var(--shine-color) 50%,
         transparent 100%
       );
       transform: translateX(-100%) translateY(-100%) rotate(30deg);
       pointer-events: none;
     }
-    button:not(.emoji-container):hover::before {
-      animation: buttonSheen 0.7s ease-out forwards;
+    button:hover::before {
+      animation: buttonSheen var(--shine-duration) ease-out forwards;
     }
     @keyframes buttonSheen {
       from { transform: translateX(-100%) translateY(-100%) rotate(30deg); }
       to   { transform: translateX(100%) translateY(100%) rotate(30deg); }
     }
 
-    /* Rating buttons & labels */
-    button.emoji-container {
-      background: none;
-      border: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
+    /* —— Emoji Rating Bar —— */
     .emoji-bar {
       display: flex;
       justify-content: center;
       gap: 1rem;
       margin: 1rem 0;
     }
+    button.emoji-container {
+      background: transparent;
+      border: none;
+      padding: 0;
+      margin: 0;
+      cursor: pointer;
+    }
+    button.emoji-container:focus { outline: none; }
+
     .emoji-container img {
       width: 6vw;
       max-width: 60px;
       min-width: 40px;
       filter: grayscale(100%);
-      transition: transform 0.2s, filter 0.2s;
+      transition: transform 0.2s ease, filter 0.2s ease;
+      display: block;
     }
-    .emoji-container:hover img { transform: scale(1.1); }
-    .emoji-container.selected img { filter: none; }
-
+    .emoji-container:hover img {
+      transform: scale(1.1);
+    }
+    .emoji-container.selected img {
+      filter: none;
+    }
     .emoji-label {
-      font-size: 0.75rem;
       color: var(--label-color);
+      font-size: 0.75rem;
       margin-top: 0.25rem;
+      text-align: center;
     }
 
-    .d-none { display: none; }
-
-    /* Popup & confetti */
+    /* —— Popup & Confetti —— */
     #popup {
       display: none;
       position: fixed; top: 50%; left: 50%;
@@ -210,40 +211,24 @@
       pointer-events: none; z-index: 9999;
     }
 
-    /*———— Mobile tweaks (≤600px) ————*/
+    /*———— Mobile optimizations ————*/
     @media (max-width: 600px) {
       header.survey-title-box,
-      form {
-        padding: 1rem;
-      }
-      .survey-title {
-        font-size: 1.5rem;
-      }
-      label, legend {
-        margin-top: 1rem;
-        font-size: 0.9rem;
-      }
-      .emoji-bar {
-        gap: 0.5rem;
-        margin: 0.75rem 0;
-      }
+      form { padding: 1rem; }
+      .survey-title { font-size: 1.5rem; }
+      label, legend { margin-top: 1rem; font-size: 0.9rem; }
+      .emoji-bar { gap: 0.5rem; margin: 0.75rem 0; }
       .emoji-container img {
-        width: 12vw;
-        max-width: 50px;
-        min-width: 30px;
+        width: 12vw; max-width: 50px; min-width: 30px;
       }
       .buttons {
         flex-direction: column;
         gap: 0.75rem;
       }
       .buttons button {
-        width: 100%;
-        min-width: auto;
+        width: 100%; min-width: auto;
       }
-      input[type="date"], select,
-      textarea {
-        font-size: 0.95rem;
-      }
+      input[type="date"], textarea { font-size: 0.95rem; }
     }
   </style>
 </head>
@@ -256,12 +241,8 @@
     <form id="surveyForm">
       <!-- Page 1 -->
       <section class="page active">
-        <label for="weekSelect">Which week are you reviewing?</label>
-        <select id="weekSelect" onchange="setWeekLabel()"></select>
-        <div id="dateGroup" class="d-none">
-          <label for="lunchDate">What day are you reviewing?</label>
-          <input type="date" id="lunchDate" name="lunchDate" required>
-        </div>
+        <label for="lunchDate">What day are you reviewing?</label>
+        <input type="date" id="lunchDate" name="lunchDate" required>
         <div class="buttons">
           <button type="button" onclick="nextPage()">Continue</button>
         </div>
@@ -269,23 +250,23 @@
 
       <!-- Page 2: Ratings -->
       <section class="page">
-        <fieldset>
-          <legend>Taste</legend>
+        <fieldset role="group" aria-labelledby="tasteLegend">
+          <legend id="tasteLegend">Taste</legend>
           <div class="emoji-bar" id="tasteRating"></div>
           <input type="hidden" id="tasteRatingInput" name="tasteRating" data-label="Taste" required>
         </fieldset>
-        <fieldset>
-          <legend>Temperature</legend>
+        <fieldset role="group" aria-labelledby="tempLegend">
+          <legend id="tempLegend">Temperature</legend>
           <div class="emoji-bar" id="temperatureRating"></div>
           <input type="hidden" id="temperatureRatingInput" name="temperatureRating" data-label="Temperature" required>
         </fieldset>
-        <fieldset>
-          <legend>Overall</legend>
+        <fieldset role="group" aria-labelledby="overallLegend">
+          <legend id="overallLegend">Overall</legend>
           <div class="emoji-bar" id="overallRating"></div>
           <input type="hidden" id="overallRatingInput" name="overallRating" data-label="Overall Experience" required>
         </fieldset>
-        <fieldset>
-          <legend>Flowers for the Chefs</legend>
+        <fieldset role="group" aria-labelledby="flowersLegend">
+          <legend id="flowersLegend">Flowers for the Chefs</legend>
           <div class="emoji-bar" id="flowersRating"></div>
           <input type="hidden" id="flowersRatingInput" name="flowersRating" data-label="Flowers for the Chefs" required>
         </fieldset>
@@ -328,23 +309,17 @@
   <script>
   (function(){
     'use strict';
-    let currentPage = 0;
-    const pages     = document.querySelectorAll('.page'),
-          form      = document.getElementById('surveyForm'),
+    const form      = document.getElementById('surveyForm'),
           dateInput = document.getElementById('lunchDate'),
-          weekSelect = document.getElementById('weekSelect');
+          pages     = document.querySelectorAll('.page'),
+          popup     = document.getElementById('popup'),
+          confetti  = document.getElementById('confettiVideo');
+    let currentPage = 0;
 
     function showPage(i) {
       pages.forEach((p, idx) => p.classList.toggle('active', idx === i));
       currentPage = i;
-      if (i === 0) {
-        if (!weekSelect.value) {
-          weekSelect.focus();
-        } else {
-          dateInput.focus();
-          if (typeof dateInput.showPicker === 'function') dateInput.showPicker();
-        }
-      }
+      if (i === 0) dateInput.showPicker?.(), dateInput.focus();
     }
 
     window.nextPage = () => {
@@ -352,69 +327,40 @@
         for (let hi of pages[1].querySelectorAll('input[type="hidden"]'))
           if (!hi.value) return alert(`Please select a rating for ${hi.dataset.label}.`);
       }
-      for (let f of pages[currentPage].querySelectorAll('input:not([type="hidden"]), textarea'))
+      for (let f of pages[currentPage].querySelectorAll('input:not([type="hidden"]),textarea'))
         if (!f.checkValidity()) { f.reportValidity(); return; }
       if (currentPage < pages.length - 1) showPage(currentPage + 1);
     };
     window.prevPage = () => { if (currentPage > 0) showPage(currentPage - 1); };
 
     window.closePopup = () => {
-      document.getElementById('popup').style.display = 'none';
-      document.getElementById('confettiVideo').style.display = 'none';
-      form.reset(); setWeekLabel(); showPage(0);
+      popup.style.display = 'none';
+      confetti.pause();
+      confetti.currentTime = 0;
+      confetti.style.display = 'none';
+      form.reset();
+      setWeekLabel();
+      showPage(0);
     };
-    window.reviewAnother = () => closePopup();
-
-    function getCurrentTuesday() {
-      const now = new Date(),
-            day = now.getDay();
-      return new Date(now.setDate(now.getDate() - (day < 2 ? day + 5 : day - 2)));
-    }
-
-    function generateWeekOptions(count = 8) {
-      const start = getCurrentTuesday();
-      const opts = { month:'numeric', day:'numeric' };
-      weekSelect.innerHTML = '';
-      const placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = 'Select a week';
-      placeholder.selected = true;
-      placeholder.defaultSelected = true;
-      placeholder.disabled = true;
-      weekSelect.append(placeholder);
-      for (let i=0;i<count;i++) {
-        const tues = new Date(start); tues.setDate(start.getDate() - i*7);
-        const end = new Date(tues); end.setDate(tues.getDate() + 2);
-        const opt = document.createElement('option');
-        opt.value = tues.toISOString().slice(0,10);
-        opt.textContent = `${tues.toLocaleDateString(undefined,opts)}–${end.toLocaleDateString(undefined,opts)}`;
-        weekSelect.append(opt);
-      }
-    }
+    window.reviewAnother = window.closePopup;
 
     function setWeekLabel() {
-      const opts = { month:'numeric', day:'numeric' },
-            lbl  = document.getElementById('surveyWeek'),
-            grp  = document.getElementById('dateGroup');
-      if (!weekSelect.value) {
-        lbl.innerText = 'Campus Lunch Survey';
-        dateInput.value = '';
-        dateInput.min = '';
-        dateInput.max = '';
-        grp.classList.add('d-none');
-        return;
-      }
-      let tues = new Date(weekSelect.value);
-      const end = new Date(tues); end.setDate(tues.getDate() + 2);
-      lbl.innerText = `Campus Lunch Survey ${tues.toLocaleDateString(undefined,opts)}–${end.toLocaleDateString(undefined,opts)}`;
-      dateInput.min = tues.toISOString().slice(0,10);
-      dateInput.max = end.toISOString().slice(0,10);
-      if (dateInput.value < dateInput.min || dateInput.value > dateInput.max) dateInput.value = '';
-      grp.classList.remove('d-none');
+      const today = new Date(),
+            d = today.getDay(),
+            diff = d < 2 ? d + 5 : d - 2;
+      const t = new Date(today.getTime());
+      t.setDate(t.getDate() - diff);
+      const th = new Date(t.getTime());
+      th.setDate(th.getDate() + 2);
+      const fmt = dt => dt.toLocaleDateString(undefined, { month:'numeric', day:'numeric' });
+      dateInput.min = t.toISOString().slice(0,10);
+      dateInput.max = th.toISOString().slice(0,10);
+      document.getElementById('surveyWeek').innerText =
+        `Campus Lunch Survey ${fmt(t)}–${fmt(th)}`;
     }
 
-    function createRatingBar(id, icons, hid) {
-      const ctr = document.getElementById(id),
+    function createRatingBar(barId, icons, hid) {
+      const ctr = document.getElementById(barId),
             hidden = document.getElementById(hid);
       ctr.innerHTML = '';
       icons.forEach((icon, idx) => {
@@ -422,36 +368,50 @@
         btn.type = 'button';
         btn.className = 'emoji-container';
         btn.setAttribute('aria-label', `${hidden.dataset.label} ${idx+1}`);
+        btn.tabIndex = 0;
+
         const img = document.createElement('img');
-        img.src = `assets/${icon}`; img.alt = ''; img.loading = 'lazy';
+        img.src = `assets/${icon}`;
+        img.alt = '';
+        img.loading = 'lazy';
+
         const lbl = document.createElement('div');
-        lbl.className = 'emoji-label'; lbl.innerText = idx + 1;
-        btn.append(img, lbl);
+        lbl.className = 'emoji-label';
+        lbl.innerText = idx+1;
+
         btn.addEventListener('click', () => {
-          Array.from(ctr.children).forEach((c,i) => c.classList.toggle('selected', i <= idx));
+          Array.from(ctr.children).forEach((c,i) =>
+            c.classList.toggle('selected', i <= idx)
+          );
           hidden.value = idx+1;
         });
+        btn.addEventListener('keydown', e => {
+          if ((e.key==='Enter'||e.key===' ') && !e.repeat) {
+            btn.click(); e.preventDefault();
+          }
+          if (e.key==='ArrowRight' && idx<icons.length-1)
+            ctr.children[idx+1].focus();
+          if (e.key==='ArrowLeft' && idx>0)
+            ctr.children[idx-1].focus();
+        });
+
+        btn.append(img, lbl);
         ctr.append(btn);
       });
     }
 
-    // Optimistic submit
     form.addEventListener('submit', e => {
       e.preventDefault();
-      // show immediately
-      document.getElementById('popup').style.display = 'block';
-      document.getElementById('confettiVideo').style.display = 'block';
-      // fire-and-forget
-      const endpoint = 'https://script.google.com/macros/s/AKfycby7B3hordJ6Q9vp4aLoYHKbOV6wuts_kZv2mPDLtAcWqzaBIy_llDEBFDmbTHp6Pj7-/exec';
-      if (navigator.sendBeacon) {
-        navigator.sendBeacon(endpoint, new FormData(form));
-      } else {
-        fetch(endpoint, { method:'POST', body:new FormData(form) }).catch(console.error);
-      }
+      const sb = form.querySelector('button[type="submit"]');
+      sb.disabled = true;
+      sb.innerText = 'Submitting…';
+      popup.style.display = 'block';
+      confetti.style.display = 'block';
+      const url = 'https://script.google.com/macros/s/AKfycby7B3hordJ6Q9vp4aLoYHKbOV6wuts_kZv2mPDLtAcWqzaBIy_llDEBFDmbTHp6Pj7-/exec';
+      if (navigator.sendBeacon) navigator.sendBeacon(url, new FormData(form));
+      else fetch(url, { method:'POST', body:new FormData(form) }).catch(console.error);
     });
 
-    // init
-    generateWeekOptions();
     setWeekLabel();
     createRatingBar('tasteRating',       ['hotdog.png','hotdog.png','hotdog.png','hotdog.png','hotdog.png'],       'tasteRatingInput');
     createRatingBar('temperatureRating', ['fire.png','fire.png','fire.png','fire.png','fire.png'],             'temperatureRatingInput');

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
       <h1 class="survey-title" id="surveyWeek"></h1>
     </header>
 
-    <form id="surveyForm">
+    <form id="multiPageForm">
       <!-- Page 1 -->
       <section class="page active">
         <label for="lunchDate">What day are you reviewing?</label>
@@ -309,7 +309,7 @@
   <script>
   (function(){
     'use strict';
-    const form      = document.getElementById('surveyForm'),
+    const form      = document.getElementById('multiPageForm'),
           dateInput = document.getElementById('lunchDate'),
           pages     = document.querySelectorAll('.page'),
           popup     = document.getElementById('popup'),
@@ -419,6 +419,37 @@
     createRatingBar('flowersRating',     ['flower.png','flower.png','flower.png','flower.png','flower.png'],   'flowersRatingInput');
     showPage(0);
   })();
+  </script>
+  <form id="surveyForm">
+    <input type="date" name="lunchDate" required>
+    <input type="number" name="tasteRating" min="1" max="5" required>
+    <input type="number" name="temperatureRating" min="1" max="5" required>
+    <input type="number" name="overallRating" min="1" max="5" required>
+    <input type="number" name="flowersRating" min="1" max="5" required>
+    <input type="text" name="memorable" placeholder="What stood out?">
+    <input type="text" name="expectations" placeholder="Did it meet expectations?">
+    <button type="submit">Submit</button>
+  </form>
+  <script>
+  document.getElementById('surveyForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const f = e.target;
+    const data = {
+      lunchDate: f.lunchDate.value,
+      tasteRating: +f.tasteRating.value,
+      temperatureRating: +f.temperatureRating.value,
+      overallRating: +f.overallRating.value,
+      flowersRating: +f.flowersRating.value,
+      memorable: f.memorable.value,
+      expectations: f.expectations.value
+    };
+    const res = await fetch('/.netlify/functions/submit-to-smartsheet', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+    const json = await res.json();
+    alert(json.message || json.error);
+  });
   </script>
 </body>
 </html>

--- a/netlify/functions/submit-to-smartsheet.js
+++ b/netlify/functions/submit-to-smartsheet.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+
+exports.handler = async (event) => {
+try {
+const b = JSON.parse(event.body);
+const cells = [
+{ columnId: 3017456917723, value: b.lunchDate },
+{ columnId: 3017456917724, value: b.tasteRating },
+{ columnId: 3017456917725, value: b.temperatureRating },
+{ columnId: 3017456917726, value: b.overallRating },
+{ columnId: 3017451145426, value: b.flowersRating },
+{ columnId: 3017451145427, value: b.memorable },
+{ columnId: 3017451145428, value: b.expectations }
+]; 
+
+await axios.post(
+  `https://api.smartsheet.com/2.0/sheets/${process.env.SMARTSHEET_SHEET_ID}/rows`,
+  [{ toTop: true, cells }],
+  {
+    headers: {
+      Authorization: `Bearer ${process.env.SMARTSHEET_API_TOKEN}`,
+      'Content-Type': 'application/json'
+    }
+  }
+);
+
+return { statusCode: 200, body: JSON.stringify({ message: 'Submitted!' }) };
+
+} catch (e) {
+return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+}
+};


### PR DESCRIPTION
## Summary
- add `.d-none` helper class
- hide date picker until a week is chosen
- generate a placeholder option for the week dropdown
- set date limits only after week selection
- focus the appropriate field when the page loads

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e8af81eb48330b2cd2eb261be18f2