### PR TITLE
Update rating assets in survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,10 +519,10 @@
     });
 
     setWeekLabel();
-    createRatingBar('tasteRating',       ['hotdog.png','hotdog.png','hotdog.png','hotdog.png','hotdog.png'],       'tasteRatingInput');
-    createRatingBar('temperatureRating', ['fire.png','fire.png','fire.png','fire.png','fire.png'],             'temperatureRatingInput');
+    createRatingBar('tasteRating',       ['frown2.png','frown1.png','neutral.png','smile1.png','smile2.png'], 'tasteRatingInput');
+    createRatingBar('temperatureRating', ['temp1.png','temp2.png','temp3.png','fire.png','fire.png'],             'temperatureRatingInput');
     createRatingBar('overallRating',     ['frown2.png','frown1.png','neutral.png','smile1.png','smile2.png'], 'overallRatingInput');
-    createRatingBar('flowersRating',     ['flower.png','flower.png','flower.png','flower.png','flower.png'],   'flowersRatingInput');
+    createRatingBar('flowersRating',     ['flower1.png','flower2.png','flower3.png','flower4.png','flower.png'],   'flowersRatingInput');
 
     // New Reusable Dishware rating bars
     createRatingBar(


### PR DESCRIPTION
## Summary
- switch taste rating icons to the same emoji set used for overall
- introduce placeholders for new temperature and flower rating assets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68827a913a3c833083270b97cb95447c