### PR TITLE
Handle missing dishware fields in survey submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,6 +536,7 @@
       sb.disabled = true;
       sb.innerText = 'Submitting…';
       const url = '/.netlify/functions/submit-to-smartsheet';
+      const optedIn = form.reuseDishwareOptInHidden.value === 'true';
       const formData = {
         lunchDate: form.lunchDate.value,
         tasteRating: +form.tasteRating.value,
@@ -543,19 +544,15 @@
         overallRating: +form.overallRating.value,
         flowersRating: +form.flowersRating.value,
         memorable: form.memorable.value,
-        expectations: form.expectations.value
+        expectations: form.expectations.value,
+        impactDishRating: optedIn ? +form.impactDishRating.value : null,
+        // Reuse the Overall-Experience emoji set here:
+        dishSatisfactionRating: optedIn ? +form.dishSatisfactionRating.value : null,
+        dishQualityRating: optedIn ? +form.dishQualityRating.value : null,
+        dishConvenienceRating: optedIn ? +form.dishConvenienceRating.value : null,
+        dishFutureRating: optedIn ? +form.dishFutureRating.value : null,
+        dishChallenges: optedIn ? form.dishChallenges.value : null
       };
-      if (form.reuseDishwareOptInHidden.value === 'true') {
-        Object.assign(formData, {
-          impactDishRating: +form.impactDishRating.value,
-          // Reuse the Overall-Experience emoji set here:
-          dishSatisfactionRating: +form.dishSatisfactionRating.value,
-          dishQualityRating: +form.dishQualityRating.value,
-          dishConvenienceRating: +form.dishConvenienceRating.value,
-          dishFutureRating: +form.dishFutureRating.value,
-          dishChallenges: form.dishChallenges.value
-        });
-      }
       fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/submit-to-smartsheet.js
+++ b/netlify/functions/submit-to-smartsheet.js
@@ -36,21 +36,21 @@ exports.handler = async (event) => {
   try {
     const b = JSON.parse(event.body);
 
-    const cells = [
-      { columnId: COL_LUNCH_DATE,        value: b.lunchDate },
-      { columnId: COL_TASTE,             value: b.tasteRating },
-      { columnId: COL_TEMPERATURE,       value: b.temperatureRating },
-      { columnId: COL_OVERALL,           value: b.overallRating },
-      { columnId: COL_FLOWERS,           value: b.flowersRating },
-      { columnId: COL_IMPACT_DISH,       value: b.impactDishRating },
-      { columnId: COL_DISH_SATISFACTION, value: b.dishSatisfactionRating },
-      { columnId: COL_DISH_QUALITY,      value: b.dishQualityRating },
-      { columnId: COL_DISH_CONVENIENCE,  value: b.dishConvenienceRating },
-      { columnId: COL_DISH_FUTURE,       value: b.dishFutureRating },
-      { columnId: COL_DISH_CHALLENGES,   value: b.dishChallenges },
-      { columnId: COL_MEMORABLE,         value: b.memorable },
-      { columnId: COL_EXPECTATIONS,      value: b.expectations }
-    ];
+      const cells = [
+        { columnId: COL_LUNCH_DATE,        value: b.lunchDate ?? null },
+        { columnId: COL_TASTE,             value: b.tasteRating ?? null },
+        { columnId: COL_TEMPERATURE,       value: b.temperatureRating ?? null },
+        { columnId: COL_OVERALL,           value: b.overallRating ?? null },
+        { columnId: COL_FLOWERS,           value: b.flowersRating ?? null },
+        { columnId: COL_IMPACT_DISH,       value: b.impactDishRating ?? null },
+        { columnId: COL_DISH_SATISFACTION, value: b.dishSatisfactionRating ?? null },
+        { columnId: COL_DISH_QUALITY,      value: b.dishQualityRating ?? null },
+        { columnId: COL_DISH_CONVENIENCE,  value: b.dishConvenienceRating ?? null },
+        { columnId: COL_DISH_FUTURE,       value: b.dishFutureRating ?? null },
+        { columnId: COL_DISH_CHALLENGES,   value: b.dishChallenges ?? null },
+        { columnId: COL_MEMORABLE,         value: b.memorable ?? null },
+        { columnId: COL_EXPECTATIONS,      value: b.expectations ?? null }
+      ];
 
     const response = await axios.post(
       `https://api.smartsheet.com/2.0/sheets/${SMARTSHEET_SHEET_ID}/rows`,


### PR DESCRIPTION
## Summary
- Always include reusable dishware fields in the submitted payload and default to `null` when the third page isn't visited
- Coalesce undefined values to `null` in Netlify's Smartsheet function so omitted fields don't break submission

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c7befa4833092f7e2265999d14c