### PR TITLE
Set default values when skipping reusable dish page

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,6 +436,20 @@
         const reuseChecked = !!(reuseOptInEl && reuseOptInEl.checked);
         const hidden = document.getElementById('reuseDishwareOptInHidden');
         if (hidden) hidden.value = reuseChecked ? 'true' : 'false';
+        if (!reuseChecked) {
+          const defaults = [
+            ['impactDishRatingInput', '0'],
+            ['dishSatisfactionRatingInput', '0'],
+            ['dishQualityRatingInput', '0'],
+            ['dishConvenienceRatingInput', '0'],
+            ['dishFutureRatingInput', '0'],
+            ['dishChallenges', 'N/A']
+          ];
+          for (const [id, value] of defaults) {
+            const el = document.getElementById(id);
+            if (el) el.value = value;
+          }
+        }
         showPage(reuseChecked ? 2 : 3);
         return;
       }


### PR DESCRIPTION
## Summary
- prefill the reusable dishware page inputs with defaults when the user opts out so validation passes while skipping the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c8888a6c8330963cc78355c1a8a6