### PR TITLE
Harden survey front end and sanitize Netlify submissions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,322 @@
+'use strict';
+
+(function () {
+  const form = document.getElementById('multiPageForm');
+  if (!form) return;
+
+  const dateInput = document.getElementById('lunchDate');
+  const pages = Array.from(document.querySelectorAll('.page'));
+  const popup = document.getElementById('popup');
+  const confetti = document.getElementById('confettiVideo');
+  const surveyWeekHeading = document.getElementById('surveyWeek');
+
+  let currentPage = 0;
+  let isSubmitting = false;
+
+  const clampRating = (value) => {
+    const rating = Number(value);
+    if (!Number.isFinite(rating)) return null;
+    const clamped = Math.max(0, Math.min(5, rating));
+    return Number.isFinite(clamped) ? clamped : null;
+  };
+
+  const cleanText = (value, maxLength = 1000) => {
+    if (typeof value !== 'string') return '';
+    return value
+      .replace(/[<>]/g, '')
+      .replace(/[\u0000-\u001F\u007F]/g, '')
+      .trim()
+      .slice(0, maxLength);
+  };
+
+  const removeChildren = (node) => {
+    while (node.firstChild) node.removeChild(node.firstChild);
+  };
+
+  const showPage = (index) => {
+    pages.forEach((page, idx) => page.classList.toggle('active', idx === index));
+    currentPage = index;
+
+    const targetPage = pages[index];
+    if (!targetPage) return;
+
+    const firstInteractive = targetPage.querySelector('input, textarea, button');
+    if (index === 0 && dateInput) {
+      if (typeof dateInput.showPicker === 'function') {
+        try { dateInput.showPicker(); } catch (_) { /* ignore */ }
+      }
+      dateInput.focus();
+    } else if (firstInteractive) {
+      firstInteractive.focus();
+    }
+  };
+
+  const setWeekLabel = () => {
+    if (!dateInput || !surveyWeekHeading) return;
+
+    const today = new Date();
+    const dayOfWeek = today.getDay();
+    const diff = dayOfWeek < 2 ? dayOfWeek + 5 : dayOfWeek - 2;
+    const start = new Date(today.getTime());
+    start.setDate(start.getDate() - diff);
+    const end = new Date(start.getTime());
+    end.setDate(end.getDate() + 2);
+
+    const formatter = (dt) => dt.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' });
+    dateInput.min = start.toISOString().slice(0, 10);
+    dateInput.max = end.toISOString().slice(0, 10);
+    surveyWeekHeading.textContent = `Campus Lunch Survey ${formatter(start)}–${formatter(end)}`;
+  };
+
+  const updateReuseDefaults = (reuseChecked) => {
+    const hidden = document.getElementById('reuseDishwareOptInHidden');
+    if (hidden) hidden.value = reuseChecked ? 'true' : 'false';
+
+    if (!reuseChecked) {
+      const defaults = [
+        ['impactDishRatingInput', '0'],
+        ['dishSatisfactionRatingInput', '0'],
+        ['dishQualityRatingInput', '0'],
+        ['dishConvenienceRatingInput', '0'],
+        ['dishFutureRatingInput', '0'],
+        ['dishChallenges', 'N/A']
+      ];
+      defaults.forEach(([id, value]) => {
+        const element = document.getElementById(id);
+        if (element) element.value = value;
+      });
+    }
+  };
+
+  const getPageIndex = (button) => {
+    const page = button.closest('.page');
+    return pages.indexOf(page);
+  };
+
+  const validatePageFields = (page) => {
+    if (!page) return false;
+
+    const hiddenInputs = page.querySelectorAll('input[type="hidden"]');
+    for (const input of hiddenInputs) {
+      if (!input.value) {
+        window.alert(`Please select a rating for ${input.dataset.label}.`);
+        return false;
+      }
+    }
+
+    const visibleFields = page.querySelectorAll('input:not([type="hidden"]), textarea');
+    for (const field of visibleFields) {
+      if (!field.checkValidity()) {
+        field.reportValidity();
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const handleNext = (event) => {
+    if (isSubmitting) return;
+
+    const button = event.currentTarget;
+    const pageIndex = getPageIndex(button);
+    if (pageIndex === -1) return;
+
+    const page = pages[pageIndex];
+    if (!validatePageFields(page)) return;
+
+    if (pageIndex === 1) {
+      const reuseOptInEl = document.getElementById('reuseOptIn');
+      const reuseChecked = Boolean(reuseOptInEl && reuseOptInEl.checked);
+      updateReuseDefaults(reuseChecked);
+      showPage(reuseChecked ? 2 : 3);
+      return;
+    }
+
+    if (pageIndex < pages.length - 1) {
+      showPage(pageIndex + 1);
+    }
+  };
+
+  const handlePrev = (event) => {
+    if (isSubmitting) return;
+
+    const button = event.currentTarget;
+    const pageIndex = getPageIndex(button);
+    if (pageIndex === -1) return;
+
+    if (pageIndex === 3) {
+      const hidden = document.getElementById('reuseDishwareOptInHidden');
+      if (hidden && hidden.value === 'false') {
+        showPage(1);
+        return;
+      }
+    }
+
+    if (pageIndex > 0) {
+      showPage(pageIndex - 1);
+    }
+  };
+
+  const closePopup = () => {
+    if (popup) popup.style.display = 'none';
+    if (confetti) {
+      confetti.pause();
+      confetti.currentTime = 0;
+      confetti.style.display = 'none';
+    }
+    form.reset();
+    setWeekLabel();
+    showPage(0);
+  };
+
+  const createRatingBar = (barId, icons, hiddenId) => {
+    const container = document.getElementById(barId);
+    const hidden = document.getElementById(hiddenId);
+    if (!container || !hidden) return;
+
+    removeChildren(container);
+    container.setAttribute('role', 'radiogroup');
+    container.setAttribute('aria-label', hidden.dataset.label);
+
+    const buttons = [];
+
+    const select = (index) => {
+      buttons.forEach((btn, idx) => {
+        btn.classList.toggle('selected', idx <= index);
+        btn.setAttribute('aria-checked', idx === index ? 'true' : 'false');
+        btn.tabIndex = idx === index ? 0 : -1;
+      });
+      hidden.value = String(index + 1);
+    };
+
+    icons.forEach((icon, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'emoji-container';
+      button.setAttribute('aria-label', `${hidden.dataset.label} ${index + 1}`);
+      button.setAttribute('role', 'radio');
+      button.setAttribute('aria-checked', 'false');
+      button.tabIndex = index === 0 ? 0 : -1;
+
+      const image = document.createElement('img');
+      image.src = `assets/${icon}`;
+      image.alt = '';
+      image.loading = 'lazy';
+
+      const label = document.createElement('div');
+      label.className = 'emoji-label';
+      label.innerText = String(index + 1);
+
+      button.addEventListener('click', () => select(index));
+      button.addEventListener('keydown', (event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) {
+          select(index);
+          event.preventDefault();
+        }
+        if (event.key === 'ArrowRight' && index < icons.length - 1) {
+          buttons[index + 1].focus();
+        }
+        if (event.key === 'ArrowLeft' && index > 0) {
+          buttons[index - 1].focus();
+        }
+      });
+
+      button.append(image, label);
+      container.append(button);
+      buttons.push(button);
+    });
+  };
+
+  document.querySelectorAll('[data-action="next-page"]').forEach((button) => {
+    button.addEventListener('click', handleNext);
+  });
+
+  document.querySelectorAll('[data-action="prev-page"]').forEach((button) => {
+    button.addEventListener('click', handlePrev);
+  });
+
+  document.querySelectorAll('[data-action="review-another"]').forEach((button) => {
+    button.addEventListener('click', closePopup);
+  });
+
+  document.querySelectorAll('[data-action="close-tab"]').forEach((button) => {
+    button.addEventListener('click', () => {
+      closePopup();
+      window.close();
+    });
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+    isSubmitting = true;
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.innerText = 'Submitting…';
+    }
+
+    const optedIn = form.reuseDishwareOptInHidden?.value === 'true';
+
+    const payload = {
+      lunchDate: cleanText(form.lunchDate.value, 32),
+      tasteRating: clampRating(form.tasteRating.value),
+      temperatureRating: clampRating(form.temperatureRating.value),
+      overallRating: clampRating(form.overallRating.value),
+      flowersRating: clampRating(form.flowersRating.value),
+      memorable: cleanText(form.memorable.value),
+      expectations: cleanText(form.expectations.value),
+      impactDishRating: optedIn ? clampRating(form.impactDishRating.value) : null,
+      dishSatisfactionRating: optedIn ? clampRating(form.dishSatisfactionRating.value) : null,
+      dishQualityRating: optedIn ? clampRating(form.dishQualityRating.value) : null,
+      dishConvenienceRating: optedIn ? clampRating(form.dishConvenienceRating.value) : null,
+      dishFutureRating: optedIn ? clampRating(form.dishFutureRating.value) : null,
+      dishChallenges: optedIn ? cleanText(form.dishChallenges.value) : null,
+      reuseDishwareOptIn: optedIn
+    };
+
+    try {
+      const response = await fetch('/.netlify/functions/submit-to-smartsheet', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        credentials: 'same-origin'
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.error || 'Submission failed');
+      }
+
+      if (popup) popup.style.display = 'block';
+      if (confetti) {
+        confetti.style.display = 'block';
+        confetti.play().catch(() => {});
+      }
+    } catch (error) {
+      console.error(error);
+      window.alert(error.message);
+    } finally {
+      isSubmitting = false;
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.innerText = 'Submit';
+      }
+    }
+  });
+
+  setWeekLabel();
+  createRatingBar('tasteRating', ['hotdog.png', 'hotdog.png', 'hotdog.png', 'hotdog.png', 'hotdog.png'], 'tasteRatingInput');
+  createRatingBar('temperatureRating', ['cold.png', 'cold.png', 'scale1.png', 'fire.png', 'fire.png'], 'temperatureRatingInput');
+  createRatingBar('overallRating', ['frown2.png', 'frown1.png', 'neutral.png', 'smile1.png', 'smile2.png'], 'overallRatingInput');
+  createRatingBar('flowersRating', ['flowers1.png', 'flowers2.png', 'flowers3.png', 'flowers4.png', 'flower.png'], 'flowersRatingInput');
+  createRatingBar('impactDishRating', ['placeholder-impact.png', 'placeholder-impact.png', 'placeholder-impact.png', 'placeholder-impact.png', 'placeholder-impact.png'], 'impactDishRatingInput');
+  createRatingBar('dishSatisfactionRating', ['frown2.png', 'frown1.png', 'neutral.png', 'smile1.png', 'smile2.png'], 'dishSatisfactionRatingInput');
+  createRatingBar('dishQualityRating', ['placeholder-quality.png', 'placeholder-quality.png', 'placeholder-quality.png', 'placeholder-quality.png', 'placeholder-quality.png'], 'dishQualityRatingInput');
+  createRatingBar('dishConvenienceRating', ['placeholder-convenience.png', 'placeholder-convenience.png', 'placeholder-convenience.png', 'placeholder-convenience.png', 'placeholder-convenience.png'], 'dishConvenienceRatingInput');
+  createRatingBar('dishFutureRating', ['placeholder-future.png', 'placeholder-future.png', 'placeholder-future.png', 'placeholder-future.png', 'placeholder-future.png'], 'dishFutureRatingInput');
+
+  showPage(0);
+})();

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="description" content="Share feedback on campus lunches" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; connect-src 'self'; img-src 'self' data:; media-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self';"/>
+  <meta name="referrer" content="same-origin" />
   <title>Campus Lunch Survey</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -252,7 +255,7 @@
         <label for="lunchDate">What day are you reviewing?</label>
         <input type="date" id="lunchDate" name="lunchDate" required>
         <div class="buttons">
-          <button type="button" onclick="nextPage()">Continue</button>
+          <button type="button" data-action="next-page">Continue</button>
         </div>
       </section>
 
@@ -287,8 +290,8 @@
         <!-- Hidden field to capture choice for submissions -->
         <input type="hidden" name="reuseDishwareOptIn" id="reuseDishwareOptInHidden" value="true" />
         <div class="buttons">
-          <button type="button" onclick="prevPage()">Back</button>
-          <button type="button" onclick="nextPage()">Continue</button>
+          <button type="button" data-action="prev-page">Back</button>
+          <button type="button" data-action="next-page">Continue</button>
         </div>
       </section>
 
@@ -365,8 +368,8 @@
         <textarea id="dishChallenges" name="dishChallenges" required></textarea>
 
         <div class="buttons">
-          <button type="button" onclick="prevPage()">Back</button>
-          <button type="button" onclick="nextPage()">Continue</button>
+          <button type="button" data-action="prev-page">Back</button>
+          <button type="button" data-action="next-page">Continue</button>
         </div>
       </section>
 
@@ -379,7 +382,7 @@
         <textarea id="expectations" name="expectations" required></textarea>
 
         <div class="buttons">
-          <button type="button" onclick="prevPage()">Back</button>
+          <button type="button" data-action="prev-page">Back</button>
           <button type="submit">Submit</button>
         </div>
       </section>
@@ -389,8 +392,8 @@
     <div id="popup">
       🎉 Thank you for submitting!<br/><br/>
       <div class="buttons">
-        <button type="button" onclick="reviewAnother()">I’m reviewing another day</button>
-        <button type="button" onclick="closeTab()">Close</button>
+        <button type="button" data-action="review-another">I’m reviewing another day</button>
+        <button type="button" data-action="close-tab">Close</button>
       </div>
     </div>
 
@@ -400,245 +403,7 @@
     </video>
   </main>
 
-  <script>
-  (function(){
-    'use strict';
-    const form      = document.getElementById('multiPageForm'),
-          dateInput = document.getElementById('lunchDate'),
-          pages     = document.querySelectorAll('.page'),
-          popup     = document.getElementById('popup'),
-          confetti  = document.getElementById('confettiVideo');
-    let currentPage = 0;
-    let isSubmitting = false;
-
-    function showPage(i) {
-      pages.forEach((p, idx) => p.classList.toggle('active', idx === i));
-      currentPage = i;
-      const first = pages[i].querySelector('input, textarea, button');
-      if (i === 0) {
-        dateInput.showPicker?.();
-        dateInput.focus();
-      } else if (first) {
-        first.focus();
-      }
-    }
-
-    window.nextPage = () => {
-      if (isSubmitting) return;
-      if (currentPage === 1 || currentPage === 2) {
-        for (const hi of pages[currentPage].querySelectorAll('input[type="hidden"]'))
-          if (!hi.value) return alert(`Please select a rating for ${hi.dataset.label}.`);
-      }
-      for (const f of pages[currentPage].querySelectorAll('input:not([type="hidden"]),textarea'))
-        if (!f.checkValidity()) { f.reportValidity(); return; }
-      if (currentPage === 1) {
-        const reuseOptInEl = document.getElementById('reuseOptIn');
-        const reuseChecked = !!(reuseOptInEl && reuseOptInEl.checked);
-        const hidden = document.getElementById('reuseDishwareOptInHidden');
-        if (hidden) hidden.value = reuseChecked ? 'true' : 'false';
-        if (!reuseChecked) {
-          const defaults = [
-            ['impactDishRatingInput', '0'],
-            ['dishSatisfactionRatingInput', '0'],
-            ['dishQualityRatingInput', '0'],
-            ['dishConvenienceRatingInput', '0'],
-            ['dishFutureRatingInput', '0'],
-            ['dishChallenges', 'N/A']
-          ];
-          for (const [id, value] of defaults) {
-            const el = document.getElementById(id);
-            if (el) el.value = value;
-          }
-        }
-        showPage(reuseChecked ? 2 : 3);
-        return;
-      }
-      if (currentPage < pages.length - 1) showPage(currentPage + 1);
-    };
-    window.prevPage = () => {
-      if (isSubmitting || currentPage === 0) return;
-      const hidden = document.getElementById('reuseDishwareOptInHidden');
-      if (currentPage === 3 && hidden && hidden.value === 'false') {
-        showPage(1);
-      } else {
-        showPage(currentPage - 1);
-      }
-    };
-
-    window.closePopup = () => {
-      popup.style.display = 'none';
-      confetti.pause();
-      confetti.currentTime = 0;
-      confetti.style.display = 'none';
-      form.reset();
-      setWeekLabel();
-      showPage(0);
-    };
-    window.reviewAnother = window.closePopup;
-    window.closeTab = () => { closePopup(); window.close(); };
-
-    function setWeekLabel() {
-      const today = new Date(),
-            d = today.getDay(),
-            diff = d < 2 ? d + 5 : d - 2;
-      const t = new Date(today.getTime());
-      t.setDate(t.getDate() - diff);
-      const th = new Date(t.getTime());
-      th.setDate(th.getDate() + 2);
-      const fmt = dt => dt.toLocaleDateString(undefined, { month:'numeric', day:'numeric' });
-      dateInput.min = t.toISOString().slice(0,10);
-      dateInput.max = th.toISOString().slice(0,10);
-      document.getElementById('surveyWeek').innerText =
-        `Campus Lunch Survey ${fmt(t)}–${fmt(th)}`;
-    }
-
-    function createRatingBar(barId, icons, hid) {
-      const ctr = document.getElementById(barId),
-            hidden = document.getElementById(hid);
-      ctr.innerHTML = '';
-      ctr.setAttribute('role', 'radiogroup');
-      ctr.setAttribute('aria-label', hidden.dataset.label);
-      const btns = [];
-      const select = idx => {
-        btns.forEach((b,i) => {
-          b.classList.toggle('selected', i <= idx);
-          b.setAttribute('aria-checked', i === idx ? 'true' : 'false');
-          b.tabIndex = i === idx ? 0 : -1;
-        });
-        hidden.value = idx + 1;
-      };
-      icons.forEach((icon, idx) => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'emoji-container';
-        btn.setAttribute('aria-label', `${hidden.dataset.label} ${idx+1}`);
-        btn.setAttribute('role', 'radio');
-        btn.setAttribute('aria-checked', 'false');
-        btn.tabIndex = idx === 0 ? 0 : -1;
-        
-        const img = document.createElement('img');
-        img.src = `assets/${icon}`;
-        img.alt = '';
-        img.loading = 'lazy';
-
-        const lbl = document.createElement('div');
-        lbl.className = 'emoji-label';
-        lbl.innerText = idx+1;
-
-        btn.addEventListener('click', () => select(idx));
-        btn.addEventListener('keydown', e => {
-          if ((e.key==='Enter'||e.key===' ') && !e.repeat) {
-            select(idx); e.preventDefault();
-          }
-          if (e.key==='ArrowRight' && idx<icons.length-1)
-            ctr.children[idx+1].focus();
-          if (e.key==='ArrowLeft' && idx>0)
-            ctr.children[idx-1].focus();
-        });
-
-        btn.append(img, lbl);
-        ctr.append(btn);
-        btns.push(btn);
-      });
-    }
-
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      if (isSubmitting) return;
-      isSubmitting = true;
-      const sb = form.querySelector('button[type="submit"]');
-      sb.disabled = true;
-      sb.innerText = 'Submitting…';
-      const url = '/.netlify/functions/submit-to-smartsheet';
-      const optedIn = form.reuseDishwareOptInHidden.value === 'true';
-      const formData = {
-        lunchDate: form.lunchDate.value,
-        tasteRating: +form.tasteRating.value,
-        temperatureRating: +form.temperatureRating.value,
-        overallRating: +form.overallRating.value,
-        flowersRating: +form.flowersRating.value,
-        memorable: form.memorable.value,
-        expectations: form.expectations.value,
-        impactDishRating: optedIn ? +form.impactDishRating.value : null,
-        // Reuse the Overall-Experience emoji set here:
-        dishSatisfactionRating: optedIn ? +form.dishSatisfactionRating.value : null,
-        dishQualityRating: optedIn ? +form.dishQualityRating.value : null,
-        dishConvenienceRating: optedIn ? +form.dishConvenienceRating.value : null,
-        dishFutureRating: optedIn ? +form.dishFutureRating.value : null,
-        dishChallenges: optedIn ? form.dishChallenges.value : null
-      };
-      fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData)
-      })
-      .then(async res => {
-        const data = await res.json();
-        if (res.ok) {
-          popup.style.display = 'block';
-          confetti.style.display = 'block';
-        } else {
-          throw new Error(data.error || 'Submission failed');
-        }
-      })
-      .catch(err => {
-        alert(err.message);
-        console.error(err);
-      })
-      .finally(() => {
-        isSubmitting = false;
-        sb.disabled = false;
-        sb.innerText = 'Submit';
-      });
-    });
-
-    setWeekLabel();
-    createRatingBar('tasteRating',       ['hotdog.png','hotdog.png','hotdog.png','hotdog.png','hotdog.png'],       'tasteRatingInput');
-    // 🌡️ Updated Temperature Rating Bar
-    createRatingBar(
-      'temperatureRating',
-      ['cold.png','cold.png','scale1.png','fire.png','fire.png'],
-      'temperatureRatingInput'
-    );
-    createRatingBar('overallRating',     ['frown2.png','frown1.png','neutral.png','smile1.png','smile2.png'], 'overallRatingInput');
-    // 🌼 Updated Flowers Rating Bar
-    createRatingBar(
-      'flowersRating',
-      ['flowers1.png','flowers2.png','flowers3.png','flowers4.png','flower.png'],
-      'flowersRatingInput'
-    );
-
-    // New Reusable Dishware rating bars
-    createRatingBar(
-      'impactDishRating',
-      ['placeholder-impact.png','placeholder-impact.png','placeholder-impact.png','placeholder-impact.png','placeholder-impact.png'],
-      'impactDishRatingInput'
-    );
-    // <-- Reworked to use the same 5 emojis as Overall Experience -->
-    createRatingBar(
-      'dishSatisfactionRating',
-      ['frown2.png','frown1.png','neutral.png','smile1.png','smile2.png'],
-      'dishSatisfactionRatingInput'
-    );
-    createRatingBar(
-      'dishQualityRating',
-      ['placeholder-quality.png','placeholder-quality.png','placeholder-quality.png','placeholder-quality.png','placeholder-quality.png'],
-      'dishQualityRatingInput'
-    );
-    createRatingBar(
-      'dishConvenienceRating',
-      ['placeholder-convenience.png','placeholder-convenience.png','placeholder-convenience.png','placeholder-convenience.png','placeholder-convenience.png'],
-      'dishConvenienceRatingInput'
-    );
-    createRatingBar(
-      'dishFutureRating',
-      ['placeholder-future.png','placeholder-future.png','placeholder-future.png','placeholder-future.png','placeholder-future.png'],
-      'dishFutureRatingInput'
-    );
-
-    showPage(0);
-  })();
-  </script>
+  <script src="assets/js/app.js" defer></script>
 </body>
 </html>
 

--- a/netlify/functions/submit-to-smartsheet.js
+++ b/netlify/functions/submit-to-smartsheet.js
@@ -5,6 +5,8 @@ if (process.env.NODE_ENV !== 'production') {
   require('dotenv').config();
 }
 
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
 // === ✅ Smartsheet Column IDs (Updated July 2025) ===
 const COL_LUNCH_DATE        = 7713250032177028;
 const COL_TASTE             = 2083750497963908;
@@ -20,38 +22,115 @@ const COL_DISH_CHALLENGES   = 2414473029308292;
 const COL_MEMORABLE         = 7144807889325956;
 const COL_EXPECTATIONS      = 1515308355112836;
 
+const clampRating = (value) => {
+  const rating = Number(value);
+  if (!Number.isFinite(rating)) return null;
+  const clamped = Math.max(0, Math.min(5, rating));
+  return Number.isFinite(clamped) ? clamped : null;
+};
+
+const cleanText = (value, maxLength = 1000) => {
+  if (typeof value !== 'string') return null;
+  const cleaned = value
+    .replace(/[<>]/g, '')
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .trim()
+    .slice(0, maxLength);
+  return cleaned.length ? cleaned : null;
+};
+
+const sanitizeDate = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : null;
+};
+
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 200, body: 'OK' };
+    return { statusCode: 405, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Method Not Allowed' }) };
   }
 
   const { SMARTSHEET_API_TOKEN, SMARTSHEET_SHEET_ID } = process.env;
   if (!SMARTSHEET_API_TOKEN || !SMARTSHEET_SHEET_ID) {
     return {
       statusCode: 500,
+      headers: JSON_HEADERS,
       body: JSON.stringify({ error: 'Missing Smartsheet credentials' })
     };
   }
 
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ error: 'Missing request body' })
+    };
+  }
+
+  let payload;
   try {
-    const b = JSON.parse(event.body);
+    payload = JSON.parse(event.body);
+  } catch (error) {
+    console.error('🚨 Invalid JSON payload', error);
+    return {
+      statusCode: 400,
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ error: 'Invalid JSON body' })
+    };
+  }
 
-      const cells = [
-        { columnId: COL_LUNCH_DATE,        value: b.lunchDate ?? null },
-        { columnId: COL_TASTE,             value: b.tasteRating ?? null },
-        { columnId: COL_TEMPERATURE,       value: b.temperatureRating ?? null },
-        { columnId: COL_OVERALL,           value: b.overallRating ?? null },
-        { columnId: COL_FLOWERS,           value: b.flowersRating ?? null },
-        { columnId: COL_IMPACT_DISH,       value: b.impactDishRating ?? null },
-        { columnId: COL_DISH_SATISFACTION, value: b.dishSatisfactionRating ?? null },
-        { columnId: COL_DISH_QUALITY,      value: b.dishQualityRating ?? null },
-        { columnId: COL_DISH_CONVENIENCE,  value: b.dishConvenienceRating ?? null },
-        { columnId: COL_DISH_FUTURE,       value: b.dishFutureRating ?? null },
-        { columnId: COL_DISH_CHALLENGES,   value: b.dishChallenges ?? null },
-        { columnId: COL_MEMORABLE,         value: b.memorable ?? null },
-        { columnId: COL_EXPECTATIONS,      value: b.expectations ?? null }
-      ];
+  const reuseDishwareOptIn = Boolean(payload.reuseDishwareOptIn);
 
+  const sanitized = {
+    lunchDate: sanitizeDate(payload.lunchDate),
+    tasteRating: clampRating(payload.tasteRating),
+    temperatureRating: clampRating(payload.temperatureRating),
+    overallRating: clampRating(payload.overallRating),
+    flowersRating: clampRating(payload.flowersRating),
+    impactDishRating: reuseDishwareOptIn ? clampRating(payload.impactDishRating) : null,
+    dishSatisfactionRating: reuseDishwareOptIn ? clampRating(payload.dishSatisfactionRating) : null,
+    dishQualityRating: reuseDishwareOptIn ? clampRating(payload.dishQualityRating) : null,
+    dishConvenienceRating: reuseDishwareOptIn ? clampRating(payload.dishConvenienceRating) : null,
+    dishFutureRating: reuseDishwareOptIn ? clampRating(payload.dishFutureRating) : null,
+    dishChallenges: reuseDishwareOptIn ? cleanText(payload.dishChallenges) : null,
+    memorable: cleanText(payload.memorable, 2000),
+    expectations: cleanText(payload.expectations, 2000)
+  };
+
+  const missingFields = [];
+  if (!sanitized.lunchDate) missingFields.push('lunchDate');
+  if (sanitized.tasteRating === null) missingFields.push('tasteRating');
+  if (sanitized.temperatureRating === null) missingFields.push('temperatureRating');
+  if (sanitized.overallRating === null) missingFields.push('overallRating');
+  if (sanitized.flowersRating === null) missingFields.push('flowersRating');
+  if (!sanitized.memorable) missingFields.push('memorable');
+  if (!sanitized.expectations) missingFields.push('expectations');
+
+  if (missingFields.length) {
+    return {
+      statusCode: 400,
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ error: `Missing or invalid fields: ${missingFields.join(', ')}` })
+    };
+  }
+
+  const cells = [
+    { columnId: COL_LUNCH_DATE,        value: sanitized.lunchDate },
+    { columnId: COL_TASTE,             value: sanitized.tasteRating },
+    { columnId: COL_TEMPERATURE,       value: sanitized.temperatureRating },
+    { columnId: COL_OVERALL,           value: sanitized.overallRating },
+    { columnId: COL_FLOWERS,           value: sanitized.flowersRating },
+    { columnId: COL_IMPACT_DISH,       value: sanitized.impactDishRating },
+    { columnId: COL_DISH_SATISFACTION, value: sanitized.dishSatisfactionRating },
+    { columnId: COL_DISH_QUALITY,      value: sanitized.dishQualityRating },
+    { columnId: COL_DISH_CONVENIENCE,  value: sanitized.dishConvenienceRating },
+    { columnId: COL_DISH_FUTURE,       value: sanitized.dishFutureRating },
+    { columnId: COL_DISH_CHALLENGES,   value: sanitized.dishChallenges },
+    { columnId: COL_MEMORABLE,         value: sanitized.memorable },
+    { columnId: COL_EXPECTATIONS,      value: sanitized.expectations }
+  ].filter(cell => cell.value !== null && cell.value !== undefined);
+
+  try {
     const response = await axios.post(
       `https://api.smartsheet.com/2.0/sheets/${SMARTSHEET_SHEET_ID}/rows`,
       [{ toTop: true, cells }],
@@ -67,6 +146,7 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
+      headers: JSON_HEADERS,
       body: JSON.stringify({ message: 'Submitted!' })
     };
 
@@ -76,6 +156,7 @@ exports.handler = async (event) => {
     console.error('🚨 Submission Error:', err.response?.data || err);
     return {
       statusCode: status,
+      headers: JSON_HEADERS,
       body: JSON.stringify({ error: message })
     };
   }


### PR DESCRIPTION
## Summary
- add a restrictive Content Security Policy and move all survey logic into an external script with strengthened client-side validation
- wire the UI buttons via delegated listeners, improve UX resets, and ensure payloads are trimmed before submission
- sanitize Netlify function inputs, validate required fields, and return structured errors while preserving Smartsheet inserts

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7224970a88330888122314baff4ea